### PR TITLE
Wrong namespace for class

### DIFF
--- a/WKHTMLToPDF.php
+++ b/WKHTMLToPDF.php
@@ -1,5 +1,5 @@
 <?php
-namespace h4cc\WKHTMLToPDF;
+namespace silvertipsoftware\WKHTMLToPDF;
 
 class WKHTMLToPDF
 {


### PR DESCRIPTION
The namespace of the WKHTMLToPDF class has not been adjusted in this fork, leading to the example in the README not being correct. The class also cannot be found through PSR-4 (only through a complete classmap).